### PR TITLE
Update moment version to fix avoid vulnerable one

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "debug": "3.0.1",
     "lazy-ass": "1.6.0",
     "lodash": "4.17.4",
-    "moment": "2.18.1",
+    "moment": "2.19.3",
     "npm-utils": "2.0.0",
     "parse-github-repo-url": "1.4.1",
     "q": "1.4.1",


### PR DESCRIPTION
The moment module before 2.19.3 is vulnerable, see [CVE-2017-18214](https://nvd.nist.gov/vuln/detail/CVE-2017-18214)